### PR TITLE
Release 5.10.0

### DIFF
--- a/GoCardless.Tests/BlockServiceTests.cs
+++ b/GoCardless.Tests/BlockServiceTests.cs
@@ -54,7 +54,7 @@ namespace GoCardless.Tests
                 ReferenceValue = "CU123",
             };
             var resp = await client.Blocks.BlockByRefAsync(request);
-            mockHttp.AssertRequestMade("POST","/block_by_ref");
+            mockHttp.AssertRequestMade("POST","/blocks/block_by_ref");
             TestHelpers.AssertResponseCanSerializeBackToFixture(resp, responseFixture);
 
             resp.Meta.Cursors.Before.Should().BeNull();

--- a/GoCardless/GoCardless.csproj
+++ b/GoCardless/GoCardless.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>GoCardless</PackageId>
-    <PackageVersion>5.9.0</PackageVersion>
+    <PackageVersion>5.10.0</PackageVersion>
     <Authors>GoCardless Ltd</Authors>
     <Description>Client for the GoCardless API - a powerful, simple solution for the collection of recurring bank-to-bank payments</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -11,7 +11,7 @@
     <Copyright>GoCardless Ltd</Copyright>
     <PackageTags>gocardless payments rest api direct debit</PackageTags>
     <PackageLicenseUrl>https://github.com/gocardless/gocardless-dotnet/blob/master/LICENSE.txt</PackageLicenseUrl>
-    <PackageReleaseNotes>https://github.com/gocardless/gocardless-dotnet/releases/tag/v5.9.0</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/gocardless/gocardless-dotnet/releases/tag/v5.10.0</PackageReleaseNotes>
     <TargetFrameworks>netstandard1.6;netstandard2.0;net46</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/GoCardless/GoCardlessClient.cs
+++ b/GoCardless/GoCardlessClient.cs
@@ -277,11 +277,11 @@ namespace GoCardless
             runtimeFrameworkInformation = System.Runtime.InteropServices.RuntimeEnvironment.GetSystemVersion();
 #endif
 
-            var userAgentInformation = $" gocardless-dotnet/5.9.0 {runtimeFrameworkInformation} {Helpers.CleanupOSDescriptionString(OSRunningOn)}";
+            var userAgentInformation = $" gocardless-dotnet/5.10.0 {runtimeFrameworkInformation} {Helpers.CleanupOSDescriptionString(OSRunningOn)}";
 
             requestMessage.Headers.Add("User-Agent", userAgentInformation);
             requestMessage.Headers.Add("GoCardless-Version", "2015-07-06");
-            requestMessage.Headers.Add("GoCardless-Client-Version", "5.9.0");
+            requestMessage.Headers.Add("GoCardless-Client-Version", "5.10.0");
             requestMessage.Headers.Add("GoCardless-Client-Library", "gocardless-dotnet");
             requestMessage.Headers.Authorization =
                 new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _accessToken);

--- a/GoCardless/Services/BlockService.cs
+++ b/GoCardless/Services/BlockService.cs
@@ -219,7 +219,7 @@ namespace GoCardless.Services
             var urlParams = new List<KeyValuePair<string, object>>
             {};
 
-            return _goCardlessClient.ExecuteAsync<BlockListResponse>("POST", "/block_by_ref", urlParams, request, null, "data", customiseRequestMessage);
+            return _goCardlessClient.ExecuteAsync<BlockListResponse>("POST", "/blocks/block_by_ref", urlParams, request, null, "data", customiseRequestMessage);
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For full details of the GoCardless API, see the [API docs](https://developer.goc
 
 To install `GoCardless`, run the following command in the [Package Manager Console](https://docs.microsoft.com/en-us/nuget/tools/package-manager-console)
 
-`Install-Package GoCardless -Version 5.9.0`
+`Install-Package GoCardless -Version 5.10.0`
 
 
 ## Usage


### PR DESCRIPTION
Update includes:
- Making `creditor_type` and `country_code` required when creating creditors via the API (for payment providers);
- Removing `null` as an allowed value for `creditor_type` when creating creditors.