### PR TITLE
Bump to v5.11.0

### DIFF
--- a/GoCardless/GoCardless.csproj
+++ b/GoCardless/GoCardless.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>GoCardless</PackageId>
-    <PackageVersion>5.10.0</PackageVersion>
+    <PackageVersion>5.11.0</PackageVersion>
     <Authors>GoCardless Ltd</Authors>
     <Description>Client for the GoCardless API - a powerful, simple solution for the collection of recurring bank-to-bank payments</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -11,7 +11,7 @@
     <Copyright>GoCardless Ltd</Copyright>
     <PackageTags>gocardless payments rest api direct debit</PackageTags>
     <PackageLicenseUrl>https://github.com/gocardless/gocardless-dotnet/blob/master/LICENSE.txt</PackageLicenseUrl>
-    <PackageReleaseNotes>https://github.com/gocardless/gocardless-dotnet/releases/tag/v5.10.0</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/gocardless/gocardless-dotnet/releases/tag/v5.11.0</PackageReleaseNotes>
     <TargetFrameworks>netstandard1.6;netstandard2.0;net46</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/GoCardless/GoCardlessClient.cs
+++ b/GoCardless/GoCardlessClient.cs
@@ -277,11 +277,11 @@ namespace GoCardless
             runtimeFrameworkInformation = System.Runtime.InteropServices.RuntimeEnvironment.GetSystemVersion();
 #endif
 
-            var userAgentInformation = $" gocardless-dotnet/5.10.0 {runtimeFrameworkInformation} {Helpers.CleanupOSDescriptionString(OSRunningOn)}";
+            var userAgentInformation = $" gocardless-dotnet/5.11.0 {runtimeFrameworkInformation} {Helpers.CleanupOSDescriptionString(OSRunningOn)}";
 
             requestMessage.Headers.Add("User-Agent", userAgentInformation);
             requestMessage.Headers.Add("GoCardless-Version", "2015-07-06");
-            requestMessage.Headers.Add("GoCardless-Client-Version", "5.10.0");
+            requestMessage.Headers.Add("GoCardless-Client-Version", "5.11.0");
             requestMessage.Headers.Add("GoCardless-Client-Library", "gocardless-dotnet");
             requestMessage.Headers.Authorization =
                 new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _accessToken);

--- a/GoCardless/Resources/BillingRequest.cs
+++ b/GoCardless/Resources/BillingRequest.cs
@@ -400,6 +400,22 @@ namespace GoCardless.Resources
     public class BillingRequestMandateRequest
     {
         /// <summary>
+        /// This field is ACH specific, sometimes referred to as [SEC
+        /// code](https://www.moderntreasury.com/learn/sec-codes).
+        /// 
+        /// This is the way that the payer gives authorisation to the merchant.
+        ///   web: Authorisation is Internet Initiated or via Mobile Entry (maps
+        /// to SEC code: WEB)
+        ///   telephone: Authorisation is provided orally over telephone (maps
+        /// to SEC code: TEL)
+        ///   paper: Authorisation is provided in writing and signed, or
+        /// similarly authenticated (maps to SEC code: PPD)
+        /// 
+        /// </summary>
+        [JsonProperty("authorisation_source")]
+        public BillingRequestMandateRequestAuthorisationSource? AuthorisationSource { get; set; }
+
+        /// <summary>
         /// Constraints that will apply to the mandate_request. (Optional)
         /// Specifically for PayTo and VRP.
         /// </summary>
@@ -477,6 +493,34 @@ namespace GoCardless.Resources
         public BillingRequestMandateRequestVerify? Verify { get; set; }
     }
     
+    /// <summary>
+    /// This field is ACH specific, sometimes referred to as [SEC
+    /// code](https://www.moderntreasury.com/learn/sec-codes).
+    /// 
+    /// This is the way that the payer gives authorisation to the merchant.
+    ///   web: Authorisation is Internet Initiated or via Mobile Entry (maps to SEC code: WEB)
+    ///   telephone: Authorisation is provided orally over telephone (maps to SEC code: TEL)
+    ///   paper: Authorisation is provided in writing and signed, or similarly authenticated (maps
+    /// to SEC code: PPD)
+    /// 
+    /// </summary>
+    [JsonConverter(typeof(GcStringEnumConverter), (int)Unknown)]
+    public enum BillingRequestMandateRequestAuthorisationSource {
+        /// <summary>Unknown status</summary>
+        [EnumMember(Value = "unknown")]
+        Unknown = 0,
+
+        /// <summary>`authorisation_source` with a value of "web"</summary>
+        [EnumMember(Value = "web")]
+        Web,
+        /// <summary>`authorisation_source` with a value of "telephone"</summary>
+        [EnumMember(Value = "telephone")]
+        Telephone,
+        /// <summary>`authorisation_source` with a value of "paper"</summary>
+        [EnumMember(Value = "paper")]
+        Paper,
+    }
+
     /// <summary>
     /// Represents a billing request mandate request constraint resource.
     ///

--- a/GoCardless/Resources/Mandate.cs
+++ b/GoCardless/Resources/Mandate.cs
@@ -20,6 +20,22 @@ namespace GoCardless.Resources
     public class Mandate
     {
         /// <summary>
+        /// This field is ACH specific, sometimes referred to as [SEC
+        /// code](https://www.moderntreasury.com/learn/sec-codes).
+        /// 
+        /// This is the way that the payer gives authorisation to the merchant.
+        ///   web: Authorisation is Internet Initiated or via Mobile Entry (maps
+        /// to SEC code: WEB)
+        ///   telephone: Authorisation is provided orally over telephone (maps
+        /// to SEC code: TEL)
+        ///   paper: Authorisation is provided in writing and signed, or
+        /// similarly authenticated (maps to SEC code: PPD)
+        /// 
+        /// </summary>
+        [JsonProperty("authorisation_source")]
+        public MandateAuthorisationSource? AuthorisationSource { get; set; }
+
+        /// <summary>
         /// (Optional) Payto and VRP Scheme specific information
         /// </summary>
         [JsonProperty("consent_parameters")]
@@ -111,6 +127,34 @@ namespace GoCardless.Resources
         public MandateStatus? Status { get; set; }
     }
     
+    /// <summary>
+    /// This field is ACH specific, sometimes referred to as [SEC
+    /// code](https://www.moderntreasury.com/learn/sec-codes).
+    /// 
+    /// This is the way that the payer gives authorisation to the merchant.
+    ///   web: Authorisation is Internet Initiated or via Mobile Entry (maps to SEC code: WEB)
+    ///   telephone: Authorisation is provided orally over telephone (maps to SEC code: TEL)
+    ///   paper: Authorisation is provided in writing and signed, or similarly authenticated (maps
+    /// to SEC code: PPD)
+    /// 
+    /// </summary>
+    [JsonConverter(typeof(GcStringEnumConverter), (int)Unknown)]
+    public enum MandateAuthorisationSource {
+        /// <summary>Unknown status</summary>
+        [EnumMember(Value = "unknown")]
+        Unknown = 0,
+
+        /// <summary>`authorisation_source` with a value of "web"</summary>
+        [EnumMember(Value = "web")]
+        Web,
+        /// <summary>`authorisation_source` with a value of "telephone"</summary>
+        [EnumMember(Value = "telephone")]
+        Telephone,
+        /// <summary>`authorisation_source` with a value of "paper"</summary>
+        [EnumMember(Value = "paper")]
+        Paper,
+    }
+
     /// <summary>
     /// Represents a mandate consent parameter resource.
     ///

--- a/GoCardless/Services/BillingRequestService.cs
+++ b/GoCardless/Services/BillingRequestService.cs
@@ -526,6 +526,50 @@ namespace GoCardless.Services
         {
                 
                 /// <summary>
+                            /// This field is ACH specific, sometimes referred to as [SEC
+            /// code](https://www.moderntreasury.com/learn/sec-codes).
+            /// 
+            /// This is the way that the payer gives authorisation to the
+            /// merchant.
+            ///   web: Authorisation is Internet Initiated or via Mobile Entry
+            /// (maps to SEC code: WEB)
+            ///   telephone: Authorisation is provided orally over telephone
+            /// (maps to SEC code: TEL)
+            ///   paper: Authorisation is provided in writing and signed, or
+            /// similarly authenticated (maps to SEC code: PPD)
+            /// 
+                /// </summary>
+                [JsonProperty("authorisation_source")]
+                public BillingRequestAuthorisationSource? AuthorisationSource { get; set; }
+        /// <summary>
+        /// This field is ACH specific, sometimes referred to as [SEC
+        /// code](https://www.moderntreasury.com/learn/sec-codes).
+        /// 
+        /// This is the way that the payer gives authorisation to the merchant.
+        ///   web: Authorisation is Internet Initiated or via Mobile Entry (maps
+        /// to SEC code: WEB)
+        ///   telephone: Authorisation is provided orally over telephone (maps
+        /// to SEC code: TEL)
+        ///   paper: Authorisation is provided in writing and signed, or
+        /// similarly authenticated (maps to SEC code: PPD)
+        /// 
+        /// </summary>
+        [JsonConverter(typeof(StringEnumConverter))]
+        public enum BillingRequestAuthorisationSource
+        {
+    
+            /// <summary>`authorisation_source` with a value of "web"</summary>
+            [EnumMember(Value = "web")]
+            Web,
+            /// <summary>`authorisation_source` with a value of "telephone"</summary>
+            [EnumMember(Value = "telephone")]
+            Telephone,
+            /// <summary>`authorisation_source` with a value of "paper"</summary>
+            [EnumMember(Value = "paper")]
+            Paper,
+        }
+                
+                /// <summary>
                             /// Constraints that will apply to the mandate_request. (Optional)
             /// Specifically for PayTo and VRP.
                 /// </summary>

--- a/GoCardless/Services/MandateService.cs
+++ b/GoCardless/Services/MandateService.cs
@@ -216,6 +216,50 @@ namespace GoCardless.Services
     {
 
         /// <summary>
+        /// This field is ACH specific, sometimes referred to as [SEC
+        /// code](https://www.moderntreasury.com/learn/sec-codes).
+        /// 
+        /// This is the way that the payer gives authorisation to the merchant.
+        ///   web: Authorisation is Internet Initiated or via Mobile Entry (maps
+        /// to SEC code: WEB)
+        ///   telephone: Authorisation is provided orally over telephone (maps
+        /// to SEC code: TEL)
+        ///   paper: Authorisation is provided in writing and signed, or
+        /// similarly authenticated (maps to SEC code: PPD)
+        /// 
+        /// </summary>
+        [JsonProperty("authorisation_source")]
+        public MandateAuthorisationSource? AuthorisationSource { get; set; }
+            
+        /// <summary>
+        /// This field is ACH specific, sometimes referred to as [SEC
+        /// code](https://www.moderntreasury.com/learn/sec-codes).
+        /// 
+        /// This is the way that the payer gives authorisation to the merchant.
+        ///   web: Authorisation is Internet Initiated or via Mobile Entry (maps
+        /// to SEC code: WEB)
+        ///   telephone: Authorisation is provided orally over telephone (maps
+        /// to SEC code: TEL)
+        ///   paper: Authorisation is provided in writing and signed, or
+        /// similarly authenticated (maps to SEC code: PPD)
+        /// 
+        /// </summary>
+        [JsonConverter(typeof(StringEnumConverter))]
+        public enum MandateAuthorisationSource
+        {
+    
+            /// <summary>`authorisation_source` with a value of "web"</summary>
+            [EnumMember(Value = "web")]
+            Web,
+            /// <summary>`authorisation_source` with a value of "telephone"</summary>
+            [EnumMember(Value = "telephone")]
+            Telephone,
+            /// <summary>`authorisation_source` with a value of "paper"</summary>
+            [EnumMember(Value = "paper")]
+            Paper,
+        }
+
+        /// <summary>
         /// Linked resources.
         /// </summary>
         [JsonProperty("links")]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For full details of the GoCardless API, see the [API docs](https://developer.goc
 
 To install `GoCardless`, run the following command in the [Package Manager Console](https://docs.microsoft.com/en-us/nuget/tools/package-manager-console)
 
-`Install-Package GoCardless -Version 5.10.0`
+`Install-Package GoCardless -Version 5.11.0`
 
 
 ## Usage


### PR DESCRIPTION
Added `authorisation_source` parameter to the [Mandate](https://developer.gocardless.com/api-reference#mandates-create-a-mandate) creation API and `mandate_request[authourisation_source]` parameter to the [BillingRequest](https://developer.gocardless.com/api-reference#billing-requests-create-a-billing-request) creation API. This field is required for offline mandates.