### PR TITLE
Release v5.12.0

### DIFF
--- a/GoCardless/GoCardless.csproj
+++ b/GoCardless/GoCardless.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>GoCardless</PackageId>
-    <PackageVersion>5.11.0</PackageVersion>
+    <PackageVersion>5.12.0</PackageVersion>
     <Authors>GoCardless Ltd</Authors>
     <Description>Client for the GoCardless API - a powerful, simple solution for the collection of recurring bank-to-bank payments</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -11,7 +11,7 @@
     <Copyright>GoCardless Ltd</Copyright>
     <PackageTags>gocardless payments rest api direct debit</PackageTags>
     <PackageLicenseUrl>https://github.com/gocardless/gocardless-dotnet/blob/master/LICENSE.txt</PackageLicenseUrl>
-    <PackageReleaseNotes>https://github.com/gocardless/gocardless-dotnet/releases/tag/v5.11.0</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/gocardless/gocardless-dotnet/releases/tag/v5.12.0</PackageReleaseNotes>
     <TargetFrameworks>netstandard1.6;netstandard2.0;net46</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/GoCardless/GoCardlessClient.Generated.cs
+++ b/GoCardless/GoCardlessClient.Generated.cs
@@ -154,6 +154,11 @@ namespace GoCardless
         public TaxRateService TaxRates => new TaxRateService(this);
 
         /// <summary>
+        ///A service for working with verification detail resources.
+        /// </summary>
+        public VerificationDetailService VerificationDetails => new VerificationDetailService(this);
+
+        /// <summary>
         ///A service for working with webhook resources.
         /// </summary>
         public WebhookService Webhooks => new WebhookService(this);

--- a/GoCardless/GoCardlessClient.Generated.cs
+++ b/GoCardless/GoCardlessClient.Generated.cs
@@ -139,6 +139,11 @@ namespace GoCardless
         public ScenarioSimulatorService ScenarioSimulators => new ScenarioSimulatorService(this);
 
         /// <summary>
+        ///A service for working with schemeentifier resources.
+        /// </summary>
+        public SchemeIdentifierService SchemeIdentifiers => new SchemeIdentifierService(this);
+
+        /// <summary>
         ///A service for working with subscription resources.
         /// </summary>
         public SubscriptionService Subscriptions => new SubscriptionService(this);

--- a/GoCardless/GoCardlessClient.cs
+++ b/GoCardless/GoCardlessClient.cs
@@ -277,11 +277,11 @@ namespace GoCardless
             runtimeFrameworkInformation = System.Runtime.InteropServices.RuntimeEnvironment.GetSystemVersion();
 #endif
 
-            var userAgentInformation = $" gocardless-dotnet/5.11.0 {runtimeFrameworkInformation} {Helpers.CleanupOSDescriptionString(OSRunningOn)}";
+            var userAgentInformation = $" gocardless-dotnet/5.12.0 {runtimeFrameworkInformation} {Helpers.CleanupOSDescriptionString(OSRunningOn)}";
 
             requestMessage.Headers.Add("User-Agent", userAgentInformation);
             requestMessage.Headers.Add("GoCardless-Version", "2015-07-06");
-            requestMessage.Headers.Add("GoCardless-Client-Version", "5.11.0");
+            requestMessage.Headers.Add("GoCardless-Client-Version", "5.12.0");
             requestMessage.Headers.Add("GoCardless-Client-Library", "gocardless-dotnet");
             requestMessage.Headers.Authorization =
                 new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _accessToken);

--- a/GoCardless/Resources/BankAuthorisation.cs
+++ b/GoCardless/Resources/BankAuthorisation.cs
@@ -73,6 +73,20 @@ namespace GoCardless.Resources
         /// <summary>
         /// URL that the payer can be redirected to after authorising the
         /// payment.
+        /// 
+        /// On completion of bank authorisation, the query parameter of either
+        /// `outcome=success` or `outcome=failure` will be
+        /// appended to the `redirect_uri` to indicate the result of the bank
+        /// authorisation. If the bank authorisation is
+        /// expired, the query parameter `outcome=timeout` will be appended to
+        /// the `redirect_uri`, in which case you should
+        /// prompt the user to try the bank authorisation step again.
+        /// 
+        /// The `redirect_uri` you provide should handle the `outcome` query
+        /// parameter for displaying the result of the
+        /// bank authorisation as outlined above.
+        /// 
+        /// Defaults to `https://pay.gocardless.com/billing/static/thankyou`.
         /// </summary>
         [JsonProperty("redirect_uri")]
         public string RedirectUri { get; set; }

--- a/GoCardless/Resources/BillingRequest.cs
+++ b/GoCardless/Resources/BillingRequest.cs
@@ -1077,6 +1077,10 @@ namespace GoCardless.Resources
         /// containing the IP address of the payer to whom the mandate belongs
         /// (i.e. as a result of their completion of a mandate setup flow in
         /// their browser).
+        /// 
+        /// Not required for creating offline mandates where
+        /// `authorisation_source` is set to telephone or paper.
+        /// 
         /// </summary>
         [JsonProperty("ip_address")]
         public string IpAddress { get; set; }

--- a/GoCardless/Resources/Creditor.cs
+++ b/GoCardless/Resources/Creditor.cs
@@ -404,7 +404,8 @@ namespace GoCardless.Resources
         public int? MinimumAdvanceNotice { get; set; }
 
         /// <summary>
-        /// The name which appears on customers' bank statements.
+        /// The name which appears on customers' bank statements. This should
+        /// usually be the merchant's trading name.
         /// </summary>
         [JsonProperty("name")]
         public string Name { get; set; }

--- a/GoCardless/Resources/Creditor.cs
+++ b/GoCardless/Resources/Creditor.cs
@@ -329,19 +329,19 @@ namespace GoCardless.Resources
     public class CreditorSchemeIdentifier
     {
         /// <summary>
-        /// The first line of the support address.
+        /// The first line of the scheme identifier's support address.
         /// </summary>
         [JsonProperty("address_line1")]
         public string AddressLine1 { get; set; }
 
         /// <summary>
-        /// The second line of the support address.
+        /// The second line of the scheme identifier's support address.
         /// </summary>
         [JsonProperty("address_line2")]
         public string AddressLine2 { get; set; }
 
         /// <summary>
-        /// The third line of the support address.
+        /// The third line of the scheme identifier's support address.
         /// </summary>
         [JsonProperty("address_line3")]
         public string AddressLine3 { get; set; }
@@ -354,7 +354,7 @@ namespace GoCardless.Resources
         public bool? CanSpecifyMandateReference { get; set; }
 
         /// <summary>
-        /// The city of the support address.
+        /// The city of the scheme identifier's support address.
         /// </summary>
         [JsonProperty("city")]
         public string City { get; set; }
@@ -367,16 +367,29 @@ namespace GoCardless.Resources
         public string CountryCode { get; set; }
 
         /// <summary>
+        /// Fixed [timestamp](#api-usage-time-zones--dates), recording when this
+        /// resource was created.
+        /// </summary>
+        [JsonProperty("created_at")]
+        public DateTimeOffset? CreatedAt { get; set; }
+
+        /// <summary>
         /// The currency of the scheme identifier.
         /// </summary>
         [JsonProperty("currency")]
         public CreditorSchemeIdentifierCurrency? Currency { get; set; }
 
         /// <summary>
-        /// The support email address.
+        /// Scheme identifier's support email address.
         /// </summary>
         [JsonProperty("email")]
         public string Email { get; set; }
+
+        /// <summary>
+        /// Unique identifier, usually beginning with "SU".
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
 
         /// <summary>
         /// The minimum interval, in working days, between the sending of a
@@ -397,13 +410,13 @@ namespace GoCardless.Resources
         public string Name { get; set; }
 
         /// <summary>
-        /// The support phone number.
+        /// Scheme identifier's support phone number.
         /// </summary>
         [JsonProperty("phone_number")]
         public string PhoneNumber { get; set; }
 
         /// <summary>
-        /// The support postal code.
+        /// The scheme identifier's support postal code.
         /// </summary>
         [JsonProperty("postal_code")]
         public string PostalCode { get; set; }
@@ -415,7 +428,8 @@ namespace GoCardless.Resources
         public string Reference { get; set; }
 
         /// <summary>
-        /// The support address region, county or department.
+        /// The scheme identifier's support address region, county or
+        /// department.
         /// </summary>
         [JsonProperty("region")]
         public string Region { get; set; }
@@ -425,6 +439,13 @@ namespace GoCardless.Resources
         /// </summary>
         [JsonProperty("scheme")]
         public CreditorSchemeIdentifierScheme? Scheme { get; set; }
+
+        /// <summary>
+        /// The status of the scheme identifier. Only `active` scheme
+        /// identifiers will be applied to a creditor and used against payments.
+        /// </summary>
+        [JsonProperty("status")]
+        public CreditorSchemeIdentifierStatus? Status { get; set; }
     }
     
     /// <summary>
@@ -507,6 +528,24 @@ namespace GoCardless.Resources
         /// <summary>`scheme` with a value of "sepa_instant_credit_transfer"</summary>
         [EnumMember(Value = "sepa_instant_credit_transfer")]
         SepaInstantCreditTransfer,
+    }
+
+    /// <summary>
+    /// The status of the scheme identifier. Only `active` scheme identifiers will be applied to a
+    /// creditor and used against payments.
+    /// </summary>
+    [JsonConverter(typeof(GcStringEnumConverter), (int)Unknown)]
+    public enum CreditorSchemeIdentifierStatus {
+        /// <summary>Unknown status</summary>
+        [EnumMember(Value = "unknown")]
+        Unknown = 0,
+
+        /// <summary>`status` with a value of "pending"</summary>
+        [EnumMember(Value = "pending")]
+        Pending,
+        /// <summary>`status` with a value of "active"</summary>
+        [EnumMember(Value = "active")]
+        Active,
     }
 
     /// <summary>

--- a/GoCardless/Resources/Creditor.cs
+++ b/GoCardless/Resources/Creditor.cs
@@ -136,7 +136,7 @@ namespace GoCardless.Resources
         public bool? MerchantResponsibleForNotifications { get; set; }
 
         /// <summary>
-        /// The creditor's name.
+        /// The creditor's trading name.
         /// </summary>
         [JsonProperty("name")]
         public string Name { get; set; }

--- a/GoCardless/Resources/Mandate.cs
+++ b/GoCardless/Resources/Mandate.cs
@@ -125,13 +125,6 @@ namespace GoCardless.Resources
         /// </summary>
         [JsonProperty("status")]
         public MandateStatus? Status { get; set; }
-
-        /// <summary>
-        /// [Timestamp](#api-usage-time-zones--dates) recording when this
-        /// mandate was verified.
-        /// </summary>
-        [JsonProperty("verified_at")]
-        public string VerifiedAt { get; set; }
     }
     
     /// <summary>

--- a/GoCardless/Resources/Mandate.cs
+++ b/GoCardless/Resources/Mandate.cs
@@ -125,6 +125,13 @@ namespace GoCardless.Resources
         /// </summary>
         [JsonProperty("status")]
         public MandateStatus? Status { get; set; }
+
+        /// <summary>
+        /// [Timestamp](#api-usage-time-zones--dates) recording when this
+        /// mandate was verified.
+        /// </summary>
+        [JsonProperty("verified_at")]
+        public string VerifiedAt { get; set; }
     }
     
     /// <summary>

--- a/GoCardless/Resources/PayerAuthorisation.cs
+++ b/GoCardless/Resources/PayerAuthorisation.cs
@@ -444,6 +444,10 @@ namespace GoCardless.Resources
         /// containing the IP address of the payer to whom the mandate belongs
         /// (i.e. as a result of their completion of a mandate setup flow in
         /// their browser).
+        /// 
+        /// Not required for creating offline mandates where
+        /// `authorisation_source` is set to telephone or paper.
+        /// 
         /// </summary>
         [JsonProperty("payer_ip_address")]
         public string PayerIpAddress { get; set; }

--- a/GoCardless/Resources/SchemeIdentifier.cs
+++ b/GoCardless/Resources/SchemeIdentifier.cs
@@ -1,0 +1,238 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using GoCardless.Internals;
+
+namespace GoCardless.Resources
+{
+
+    /// <summary>
+    /// Represents a schemeentifier resource.
+    ///
+    /// Scheme identifiers
+    /// </summary>
+    public class SchemeIdentifier
+    {
+        /// <summary>
+        /// The first line of the scheme identifier's support address.
+        /// </summary>
+        [JsonProperty("address_line1")]
+        public string AddressLine1 { get; set; }
+
+        /// <summary>
+        /// The second line of the scheme identifier's support address.
+        /// </summary>
+        [JsonProperty("address_line2")]
+        public string AddressLine2 { get; set; }
+
+        /// <summary>
+        /// The third line of the scheme identifier's support address.
+        /// </summary>
+        [JsonProperty("address_line3")]
+        public string AddressLine3 { get; set; }
+
+        /// <summary>
+        /// Whether a custom reference can be submitted for mandates using this
+        /// scheme identifier.
+        /// </summary>
+        [JsonProperty("can_specify_mandate_reference")]
+        public bool? CanSpecifyMandateReference { get; set; }
+
+        /// <summary>
+        /// The city of the scheme identifier's support address.
+        /// </summary>
+        [JsonProperty("city")]
+        public string City { get; set; }
+
+        /// <summary>
+        /// [ISO 3166-1 alpha-2
+        /// code.](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements)
+        /// </summary>
+        [JsonProperty("country_code")]
+        public string CountryCode { get; set; }
+
+        /// <summary>
+        /// Fixed [timestamp](#api-usage-time-zones--dates), recording when this
+        /// resource was created.
+        /// </summary>
+        [JsonProperty("created_at")]
+        public DateTimeOffset? CreatedAt { get; set; }
+
+        /// <summary>
+        /// The currency of the scheme identifier.
+        /// </summary>
+        [JsonProperty("currency")]
+        public SchemeIdentifierCurrency? Currency { get; set; }
+
+        /// <summary>
+        /// Scheme identifier's support email address.
+        /// </summary>
+        [JsonProperty("email")]
+        public string Email { get; set; }
+
+        /// <summary>
+        /// Unique identifier, usually beginning with "SU".
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// The minimum interval, in working days, between the sending of a
+        /// pre-notification to the customer, and the charge date of a payment
+        /// using this scheme identifier.
+        /// 
+        /// By default, GoCardless sends these notifications automatically.
+        /// Please see our [compliance
+        /// requirements](#appendix-compliance-requirements) for more details.
+        /// </summary>
+        [JsonProperty("minimum_advance_notice")]
+        public int? MinimumAdvanceNotice { get; set; }
+
+        /// <summary>
+        /// The name which appears on customers' bank statements.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Scheme identifier's support phone number.
+        /// </summary>
+        [JsonProperty("phone_number")]
+        public string PhoneNumber { get; set; }
+
+        /// <summary>
+        /// The scheme identifier's support postal code.
+        /// </summary>
+        [JsonProperty("postal_code")]
+        public string PostalCode { get; set; }
+
+        /// <summary>
+        /// The scheme-unique identifier against which payments are submitted.
+        /// </summary>
+        [JsonProperty("reference")]
+        public string Reference { get; set; }
+
+        /// <summary>
+        /// The scheme identifier's support address region, county or
+        /// department.
+        /// </summary>
+        [JsonProperty("region")]
+        public string Region { get; set; }
+
+        /// <summary>
+        /// The scheme which this scheme identifier applies to.
+        /// </summary>
+        [JsonProperty("scheme")]
+        public SchemeIdentifierScheme? Scheme { get; set; }
+
+        /// <summary>
+        /// The status of the scheme identifier. Only `active` scheme
+        /// identifiers will be applied to a creditor and used against payments.
+        /// </summary>
+        [JsonProperty("status")]
+        public SchemeIdentifierStatus? Status { get; set; }
+    }
+    
+    /// <summary>
+    /// The currency of the scheme identifier.
+    /// </summary>
+    [JsonConverter(typeof(GcStringEnumConverter), (int)Unknown)]
+    public enum SchemeIdentifierCurrency {
+        /// <summary>Unknown status</summary>
+        [EnumMember(Value = "unknown")]
+        Unknown = 0,
+
+        /// <summary>`currency` with a value of "AUD"</summary>
+        [EnumMember(Value = "AUD")]
+        AUD,
+        /// <summary>`currency` with a value of "CAD"</summary>
+        [EnumMember(Value = "CAD")]
+        CAD,
+        /// <summary>`currency` with a value of "DKK"</summary>
+        [EnumMember(Value = "DKK")]
+        DKK,
+        /// <summary>`currency` with a value of "EUR"</summary>
+        [EnumMember(Value = "EUR")]
+        EUR,
+        /// <summary>`currency` with a value of "GBP"</summary>
+        [EnumMember(Value = "GBP")]
+        GBP,
+        /// <summary>`currency` with a value of "NZD"</summary>
+        [EnumMember(Value = "NZD")]
+        NZD,
+        /// <summary>`currency` with a value of "SEK"</summary>
+        [EnumMember(Value = "SEK")]
+        SEK,
+        /// <summary>`currency` with a value of "USD"</summary>
+        [EnumMember(Value = "USD")]
+        USD,
+    }
+
+    /// <summary>
+    /// The scheme which this scheme identifier applies to.
+    /// </summary>
+    [JsonConverter(typeof(GcStringEnumConverter), (int)Unknown)]
+    public enum SchemeIdentifierScheme {
+        /// <summary>Unknown status</summary>
+        [EnumMember(Value = "unknown")]
+        Unknown = 0,
+
+        /// <summary>`scheme` with a value of "ach"</summary>
+        [EnumMember(Value = "ach")]
+        Ach,
+        /// <summary>`scheme` with a value of "autogiro"</summary>
+        [EnumMember(Value = "autogiro")]
+        Autogiro,
+        /// <summary>`scheme` with a value of "bacs"</summary>
+        [EnumMember(Value = "bacs")]
+        Bacs,
+        /// <summary>`scheme` with a value of "becs"</summary>
+        [EnumMember(Value = "becs")]
+        Becs,
+        /// <summary>`scheme` with a value of "becs_nz"</summary>
+        [EnumMember(Value = "becs_nz")]
+        BecsNz,
+        /// <summary>`scheme` with a value of "betalingsservice"</summary>
+        [EnumMember(Value = "betalingsservice")]
+        Betalingsservice,
+        /// <summary>`scheme` with a value of "faster_payments"</summary>
+        [EnumMember(Value = "faster_payments")]
+        FasterPayments,
+        /// <summary>`scheme` with a value of "pad"</summary>
+        [EnumMember(Value = "pad")]
+        Pad,
+        /// <summary>`scheme` with a value of "pay_to"</summary>
+        [EnumMember(Value = "pay_to")]
+        PayTo,
+        /// <summary>`scheme` with a value of "sepa"</summary>
+        [EnumMember(Value = "sepa")]
+        Sepa,
+        /// <summary>`scheme` with a value of "sepa_credit_transfer"</summary>
+        [EnumMember(Value = "sepa_credit_transfer")]
+        SepaCreditTransfer,
+        /// <summary>`scheme` with a value of "sepa_instant_credit_transfer"</summary>
+        [EnumMember(Value = "sepa_instant_credit_transfer")]
+        SepaInstantCreditTransfer,
+    }
+
+    /// <summary>
+    /// The status of the scheme identifier. Only `active` scheme identifiers will be applied to a
+    /// creditor and used against payments.
+    /// </summary>
+    [JsonConverter(typeof(GcStringEnumConverter), (int)Unknown)]
+    public enum SchemeIdentifierStatus {
+        /// <summary>Unknown status</summary>
+        [EnumMember(Value = "unknown")]
+        Unknown = 0,
+
+        /// <summary>`status` with a value of "pending"</summary>
+        [EnumMember(Value = "pending")]
+        Pending,
+        /// <summary>`status` with a value of "active"</summary>
+        [EnumMember(Value = "active")]
+        Active,
+    }
+
+}

--- a/GoCardless/Resources/SchemeIdentifier.cs
+++ b/GoCardless/Resources/SchemeIdentifier.cs
@@ -11,7 +11,10 @@ namespace GoCardless.Resources
     /// <summary>
     /// Represents a schemeentifier resource.
     ///
-    /// Scheme identifiers
+    /// This represents a scheme identifier (e.g. a SUN in Bacs or a CID in
+    /// SEPA). Scheme identifiers are used to specify the beneficiary name that
+    /// appears on customers' bank statements.
+    /// 
     /// </summary>
     public class SchemeIdentifier
     {
@@ -91,7 +94,8 @@ namespace GoCardless.Resources
         public int? MinimumAdvanceNotice { get; set; }
 
         /// <summary>
-        /// The name which appears on customers' bank statements.
+        /// The name which appears on customers' bank statements. This should
+        /// usually be the merchant's trading name.
         /// </summary>
         [JsonProperty("name")]
         public string Name { get; set; }

--- a/GoCardless/Resources/VerificationDetail.cs
+++ b/GoCardless/Resources/VerificationDetail.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using GoCardless.Internals;
+
+namespace GoCardless.Resources
+{
+
+    /// <summary>
+    /// Represents a verification detail resource.
+    ///
+    /// Details of a creditor that are required for verification
+    /// </summary>
+    public class VerificationDetail
+    {
+        /// <summary>
+        /// The first line of the company's address.
+        /// </summary>
+        [JsonProperty("address_line1")]
+        public string AddressLine1 { get; set; }
+
+        /// <summary>
+        /// The second line of the company's address.
+        /// </summary>
+        [JsonProperty("address_line2")]
+        public string AddressLine2 { get; set; }
+
+        /// <summary>
+        /// The third line of the company's address.
+        /// </summary>
+        [JsonProperty("address_line3")]
+        public string AddressLine3 { get; set; }
+
+        /// <summary>
+        /// The city of the company's address.
+        /// </summary>
+        [JsonProperty("city")]
+        public string City { get; set; }
+
+        /// <summary>
+        /// The company's registration number.
+        /// </summary>
+        [JsonProperty("company_number")]
+        public string CompanyNumber { get; set; }
+
+        /// <summary>
+        /// A summary describing what the company does.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The company's directors.
+        /// </summary>
+        [JsonProperty("directors")]
+        public List<VerificationDetailDirector> Directors { get; set; }
+
+        /// <summary>
+        /// Resources linked to this VerificationDetail.
+        /// </summary>
+        [JsonProperty("links")]
+        public VerificationDetailLinks Links { get; set; }
+
+        /// <summary>
+        /// The company's postal code.
+        /// </summary>
+        [JsonProperty("postal_code")]
+        public string PostalCode { get; set; }
+    }
+    
+    /// <summary>
+    /// Represents a verification detail director resource.
+    ///
+    /// A primary director of the company represented by the creditor.
+    /// </summary>
+    public class VerificationDetailDirector
+    {
+        /// <summary>
+        /// The city of the person's address.
+        /// </summary>
+        [JsonProperty("city")]
+        public string City { get; set; }
+
+        /// <summary>
+        /// [ISO 3166-1 alpha-2
+        /// code.](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements)
+        /// </summary>
+        [JsonProperty("country_code")]
+        public string CountryCode { get; set; }
+
+        /// <summary>
+        /// The person's date of birth.
+        /// </summary>
+        [JsonProperty("date_of_birth")]
+        public string DateOfBirth { get; set; }
+
+        /// <summary>
+        /// The person's family name.
+        /// </summary>
+        [JsonProperty("family_name")]
+        public string FamilyName { get; set; }
+
+        /// <summary>
+        /// The person's given name.
+        /// </summary>
+        [JsonProperty("given_name")]
+        public string GivenName { get; set; }
+
+        /// <summary>
+        /// The person's postal code.
+        /// </summary>
+        [JsonProperty("postal_code")]
+        public string PostalCode { get; set; }
+
+        /// <summary>
+        /// The street of the person's address.
+        /// </summary>
+        [JsonProperty("street")]
+        public string Street { get; set; }
+    }
+    
+    /// <summary>
+    /// Resources linked to this VerificationDetail
+    /// </summary>
+    public class VerificationDetailLinks
+    {
+        /// <summary>
+        /// ID of the [creditor](#core-endpoints-creditors)
+        /// </summary>
+        [JsonProperty("creditor")]
+        public string Creditor { get; set; }
+    }
+    
+}

--- a/GoCardless/Services/BankAuthorisationService.cs
+++ b/GoCardless/Services/BankAuthorisationService.cs
@@ -144,6 +144,20 @@ namespace GoCardless.Services
         /// <summary>
         /// URL that the payer can be redirected to after authorising the
         /// payment.
+        /// 
+        /// On completion of bank authorisation, the query parameter of either
+        /// `outcome=success` or `outcome=failure` will be
+        /// appended to the `redirect_uri` to indicate the result of the bank
+        /// authorisation. If the bank authorisation is
+        /// expired, the query parameter `outcome=timeout` will be appended to
+        /// the `redirect_uri`, in which case you should
+        /// prompt the user to try the bank authorisation step again.
+        /// 
+        /// The `redirect_uri` you provide should handle the `outcome` query
+        /// parameter for displaying the result of the
+        /// bank authorisation as outlined above.
+        /// 
+        /// Defaults to `https://pay.gocardless.com/billing/static/thankyou`.
         /// </summary>
         [JsonProperty("redirect_uri")]
         public string RedirectUri { get; set; }

--- a/GoCardless/Services/BillingRequestService.cs
+++ b/GoCardless/Services/BillingRequestService.cs
@@ -1052,6 +1052,10 @@ namespace GoCardless.Services
             /// containing the IP address of the payer to whom the mandate
             /// belongs (i.e. as a result of their completion of a mandate setup
             /// flow in their browser).
+            /// 
+            /// Not required for creating offline mandates where
+            /// `authorisation_source` is set to telephone or paper.
+            /// 
                 /// </summary>
                 [JsonProperty("ip_address")]
                 public string IpAddress { get; set; }

--- a/GoCardless/Services/CreditorService.cs
+++ b/GoCardless/Services/CreditorService.cs
@@ -159,30 +159,6 @@ namespace GoCardless.Services
     {
 
         /// <summary>
-        /// The first line of the creditor's address.
-        /// </summary>
-        [JsonProperty("address_line1")]
-        public string AddressLine1 { get; set; }
-
-        /// <summary>
-        /// The second line of the creditor's address.
-        /// </summary>
-        [JsonProperty("address_line2")]
-        public string AddressLine2 { get; set; }
-
-        /// <summary>
-        /// The third line of the creditor's address.
-        /// </summary>
-        [JsonProperty("address_line3")]
-        public string AddressLine3 { get; set; }
-
-        /// <summary>
-        /// The city of the creditor's address.
-        /// </summary>
-        [JsonProperty("city")]
-        public string City { get; set; }
-
-        /// <summary>
         /// [ISO 3166-1 alpha-2
         /// code.](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements)
         /// </summary>
@@ -232,18 +208,6 @@ namespace GoCardless.Services
         /// </summary>
         [JsonProperty("name")]
         public string Name { get; set; }
-
-        /// <summary>
-        /// The creditor's postal code.
-        /// </summary>
-        [JsonProperty("postal_code")]
-        public string PostalCode { get; set; }
-
-        /// <summary>
-        /// The creditor's address region, county or department.
-        /// </summary>
-        [JsonProperty("region")]
-        public string Region { get; set; }
 
         /// <summary>
         /// A unique key to ensure that this request only succeeds once, allowing you to safely retry request errors such as network failures.

--- a/GoCardless/Services/CreditorService.cs
+++ b/GoCardless/Services/CreditorService.cs
@@ -149,6 +149,33 @@ namespace GoCardless.Services
 
             return _goCardlessClient.ExecuteAsync<CreditorResponse>("PUT", "/creditors/:identity", urlParams, request, null, "creditors", customiseRequestMessage);
         }
+
+        /// <summary>
+        /// Applies a [scheme identifier](#core-endpoints-scheme-identifiers) to
+        /// a creditor.
+        /// If the creditor already has a scheme identifier for the scheme, it
+        /// will be replaced,
+        /// and any mandates attached to it transferred asynchronously.
+        /// For some schemes, the application of the scheme identifier will be
+        /// performed asynchronously.
+        /// 
+        /// </summary>  
+        /// <param name="identity">Unique identifier, beginning with "CR".</param> 
+        /// <param name="request">An optional `CreditorApplySchemeIdentifierRequest` representing the body for this apply_scheme_identifier request.</param>
+        /// <param name="customiseRequestMessage">An optional `RequestSettings` allowing you to configure the request</param>
+        /// <returns>A single creditor resource</returns>
+        public Task<CreditorResponse> ApplySchemeIdentifierAsync(string identity, CreditorApplySchemeIdentifierRequest request = null, RequestSettings customiseRequestMessage = null)
+        {
+            request = request ?? new CreditorApplySchemeIdentifierRequest();
+            if (identity == null) throw new ArgumentException(nameof(identity));
+
+            var urlParams = new List<KeyValuePair<string, object>>
+            {
+                new KeyValuePair<string, object>("identity", identity),
+            };
+
+            return _goCardlessClient.ExecuteAsync<CreditorResponse>("POST", "/creditors/:identity/actions/apply_scheme_identifier", urlParams, request, null, "data", customiseRequestMessage);
+        }
     }
 
         
@@ -413,6 +440,39 @@ namespace GoCardless.Services
         /// </summary>
         [JsonProperty("region")]
         public string Region { get; set; }
+    }
+
+        
+    /// <summary>
+    /// Applies a [scheme identifier](#core-endpoints-scheme-identifiers) to a
+    /// creditor.
+    /// If the creditor already has a scheme identifier for the scheme, it will
+    /// be replaced,
+    /// and any mandates attached to it transferred asynchronously.
+    /// For some schemes, the application of the scheme identifier will be
+    /// performed asynchronously.
+    /// 
+    /// </summary>
+    public class CreditorApplySchemeIdentifierRequest
+    {
+
+        /// <summary>
+        /// The ID of the scheme identifier to apply
+        /// </summary>
+        [JsonProperty("links")]
+        public CreditorLinks Links { get; set; }
+        /// <summary>
+        /// Linked resources for a Creditor.
+        /// </summary>
+        public class CreditorLinks
+        {
+                
+                /// <summary>
+                            /// Unique identifier, usually beginning with "SU".
+                /// </summary>
+                [JsonProperty("scheme_identifier")]
+                public string SchemeIdentifier { get; set; }
+        }
     }
 
     /// <summary>

--- a/GoCardless/Services/CreditorService.cs
+++ b/GoCardless/Services/CreditorService.cs
@@ -204,7 +204,7 @@ namespace GoCardless.Services
         public IDictionary<String, String> Links { get; set; }
 
         /// <summary>
-        /// The creditor's name.
+        /// The creditor's trading name.
         /// </summary>
         [JsonProperty("name")]
         public string Name { get; set; }
@@ -397,7 +397,7 @@ namespace GoCardless.Services
         }
 
         /// <summary>
-        /// The creditor's name.
+        /// The creditor's trading name.
         /// </summary>
         [JsonProperty("name")]
         public string Name { get; set; }

--- a/GoCardless/Services/MandateService.cs
+++ b/GoCardless/Services/MandateService.cs
@@ -298,6 +298,10 @@ namespace GoCardless.Services
         /// containing the IP address of the payer to whom the mandate belongs
         /// (i.e. as a result of their completion of a mandate setup flow in
         /// their browser).
+        /// 
+        /// Not required for creating offline mandates where
+        /// `authorisation_source` is set to telephone or paper.
+        /// 
         /// </summary>
         [JsonProperty("payer_ip_address")]
         public string PayerIpAddress { get; set; }

--- a/GoCardless/Services/PayerAuthorisationService.cs
+++ b/GoCardless/Services/PayerAuthorisationService.cs
@@ -509,6 +509,10 @@ namespace GoCardless.Services
             /// containing the IP address of the payer to whom the mandate
             /// belongs (i.e. as a result of their completion of a mandate setup
             /// flow in their browser).
+            /// 
+            /// Not required for creating offline mandates where
+            /// `authorisation_source` is set to telephone or paper.
+            /// 
                 /// </summary>
                 [JsonProperty("payer_ip_address")]
                 public string PayerIpAddress { get; set; }
@@ -866,6 +870,10 @@ namespace GoCardless.Services
             /// containing the IP address of the payer to whom the mandate
             /// belongs (i.e. as a result of their completion of a mandate setup
             /// flow in their browser).
+            /// 
+            /// Not required for creating offline mandates where
+            /// `authorisation_source` is set to telephone or paper.
+            /// 
                 /// </summary>
                 [JsonProperty("payer_ip_address")]
                 public string PayerIpAddress { get; set; }

--- a/GoCardless/Services/SchemeIdentifierService.cs
+++ b/GoCardless/Services/SchemeIdentifierService.cs
@@ -16,7 +16,10 @@ namespace GoCardless.Services
     /// <summary>
     /// Service class for working with scheme identifier resources.
     ///
-    /// Scheme identifiers
+    /// This represents a scheme identifier (e.g. a SUN in Bacs or a CID in
+    /// SEPA). Scheme identifiers are used to specify the beneficiary name that
+    /// appears on customers' bank statements.
+    /// 
     /// </summary>
 
     public class SchemeIdentifierService
@@ -30,6 +33,28 @@ namespace GoCardless.Services
         public SchemeIdentifierService(GoCardlessClient goCardlessClient)
         {
             _goCardlessClient = goCardlessClient;
+        }
+
+        /// <summary>
+        /// Creates a new scheme identifier. The scheme identifier must be
+        /// [applied to a creditor](#creditors-apply-a-scheme-identifier) before
+        /// payments are taken using it. The scheme identifier must also have
+        /// the `status` of active before it can be used. For some schemes e.g.
+        /// faster_payments this will happen instantly. For other schemes e.g.
+        /// bacs this can take several days.
+        /// 
+        /// </summary>
+        /// <param name="request">An optional `SchemeIdentifierCreateRequest` representing the body for this create request.</param>
+        /// <param name="customiseRequestMessage">An optional `RequestSettings` allowing you to configure the request</param>
+        /// <returns>A single scheme identifier resource</returns>
+        public Task<SchemeIdentifierResponse> CreateAsync(SchemeIdentifierCreateRequest request = null, RequestSettings customiseRequestMessage = null)
+        {
+            request = request ?? new SchemeIdentifierCreateRequest();
+
+            var urlParams = new List<KeyValuePair<string, object>>
+            {};
+
+            return _goCardlessClient.ExecuteAsync<SchemeIdentifierResponse>("POST", "/scheme_identifiers", urlParams, request, id => GetAsync(id, null, customiseRequestMessage), "scheme_identifiers", customiseRequestMessage);
         }
 
         /// <summary>
@@ -106,6 +131,86 @@ namespace GoCardless.Services
 
             return _goCardlessClient.ExecuteAsync<SchemeIdentifierResponse>("GET", "/scheme_identifiers/:identity", urlParams, request, null, null, customiseRequestMessage);
         }
+    }
+
+        
+    /// <summary>
+    /// Creates a new scheme identifier. The scheme identifier must be [applied
+    /// to a creditor](#creditors-apply-a-scheme-identifier) before payments are
+    /// taken using it. The scheme identifier must also have the `status` of
+    /// active before it can be used. For some schemes e.g. faster_payments this
+    /// will happen instantly. For other schemes e.g. bacs this can take several
+    /// days.
+    /// 
+    /// </summary>
+    public class SchemeIdentifierCreateRequest : IHasIdempotencyKey
+    {
+
+        /// <summary>
+        /// The name which appears on customers' bank statements. This should
+        /// usually be the merchant's trading name.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The scheme which this scheme identifier applies to.
+        /// </summary>
+        [JsonProperty("scheme")]
+        public SchemeIdentifierScheme? Scheme { get; set; }
+            
+        /// <summary>
+        /// The scheme which this scheme identifier applies to.
+        /// </summary>
+        [JsonConverter(typeof(StringEnumConverter))]
+        public enum SchemeIdentifierScheme
+        {
+    
+            /// <summary>`scheme` with a value of "ach"</summary>
+            [EnumMember(Value = "ach")]
+            Ach,
+            /// <summary>`scheme` with a value of "autogiro"</summary>
+            [EnumMember(Value = "autogiro")]
+            Autogiro,
+            /// <summary>`scheme` with a value of "bacs"</summary>
+            [EnumMember(Value = "bacs")]
+            Bacs,
+            /// <summary>`scheme` with a value of "becs"</summary>
+            [EnumMember(Value = "becs")]
+            Becs,
+            /// <summary>`scheme` with a value of "becs_nz"</summary>
+            [EnumMember(Value = "becs_nz")]
+            BecsNz,
+            /// <summary>`scheme` with a value of "betalingsservice"</summary>
+            [EnumMember(Value = "betalingsservice")]
+            Betalingsservice,
+            /// <summary>`scheme` with a value of "faster_payments"</summary>
+            [EnumMember(Value = "faster_payments")]
+            FasterPayments,
+            /// <summary>`scheme` with a value of "pad"</summary>
+            [EnumMember(Value = "pad")]
+            Pad,
+            /// <summary>`scheme` with a value of "pay_to"</summary>
+            [EnumMember(Value = "pay_to")]
+            PayTo,
+            /// <summary>`scheme` with a value of "sepa"</summary>
+            [EnumMember(Value = "sepa")]
+            Sepa,
+            /// <summary>`scheme` with a value of "sepa_credit_transfer"</summary>
+            [EnumMember(Value = "sepa_credit_transfer")]
+            SepaCreditTransfer,
+            /// <summary>`scheme` with a value of "sepa_instant_credit_transfer"</summary>
+            [EnumMember(Value = "sepa_instant_credit_transfer")]
+            SepaInstantCreditTransfer,
+        }
+
+        /// <summary>
+        /// A unique key to ensure that this request only succeeds once, allowing you to safely retry request errors such as network failures.
+        /// Any requests, where supported, to create a resource with a key that has previously been used will not succeed.
+        /// See: https://developer.gocardless.com/api-reference/#making-requests-idempotency-keys
+        /// </summary>
+        [JsonIgnore]
+        public string IdempotencyKey { get; set; }
     }
 
         

--- a/GoCardless/Services/SchemeIdentifierService.cs
+++ b/GoCardless/Services/SchemeIdentifierService.cs
@@ -1,0 +1,173 @@
+
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using GoCardless.Internals;
+using GoCardless.Resources;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace GoCardless.Services
+{
+    /// <summary>
+    /// Service class for working with scheme identifier resources.
+    ///
+    /// Scheme identifiers
+    /// </summary>
+
+    public class SchemeIdentifierService
+    {
+        private readonly GoCardlessClient _goCardlessClient;
+
+        /// <summary>
+        /// Constructor. Users of this library should not call this. An instance of this
+        /// class can be accessed through an initialised GoCardlessClient.
+        /// </summary>
+        public SchemeIdentifierService(GoCardlessClient goCardlessClient)
+        {
+            _goCardlessClient = goCardlessClient;
+        }
+
+        /// <summary>
+        /// Returns a [cursor-paginated](#api-usage-cursor-pagination) list of
+        /// your scheme identifiers.
+        /// </summary>
+        /// <param name="request">An optional `SchemeIdentifierListRequest` representing the query parameters for this list request.</param>
+        /// <param name="customiseRequestMessage">An optional `RequestSettings` allowing you to configure the request</param>
+        /// <returns>A set of scheme identifier resources</returns>
+        public Task<SchemeIdentifierListResponse> ListAsync(SchemeIdentifierListRequest request = null, RequestSettings customiseRequestMessage = null)
+        {
+            request = request ?? new SchemeIdentifierListRequest();
+
+            var urlParams = new List<KeyValuePair<string, object>>
+            {};
+
+            return _goCardlessClient.ExecuteAsync<SchemeIdentifierListResponse>("GET", "/scheme_identifiers", urlParams, request, null, null, customiseRequestMessage);
+        }
+
+        /// <summary>
+        /// Get a lazily enumerated list of scheme identifiers.
+        /// This acts like the #list method, but paginates for you automatically.
+        /// </summary>
+        public IEnumerable<SchemeIdentifier> All(SchemeIdentifierListRequest request = null, RequestSettings customiseRequestMessage = null)
+        {
+            request = request ?? new SchemeIdentifierListRequest();
+
+            string cursor = null;
+            do
+            {
+                request.After = cursor;
+
+                var result = Task.Run(() => ListAsync(request, customiseRequestMessage)).Result;
+                foreach (var item in result.SchemeIdentifiers)
+                {
+                    yield return item;
+                }
+                cursor = result.Meta?.Cursors?.After;
+            } while (cursor != null);
+        }
+
+        /// <summary>
+        /// Get a lazily enumerated list of scheme identifiers.
+        /// This acts like the #list method, but paginates for you automatically.
+        /// </summary>
+        public IEnumerable<Task<IReadOnlyList<SchemeIdentifier>>> AllAsync(SchemeIdentifierListRequest request = null, RequestSettings customiseRequestMessage = null)
+        {
+            request = request ?? new SchemeIdentifierListRequest();
+
+            return new TaskEnumerable<IReadOnlyList<SchemeIdentifier>, string>(async after =>
+            {
+                request.After = after;
+                var list = await this.ListAsync(request, customiseRequestMessage);
+                return Tuple.Create(list.SchemeIdentifiers, list.Meta?.Cursors?.After);
+            });
+        }
+
+        /// <summary>
+        /// Retrieves the details of an existing scheme identifier.
+        /// </summary>  
+        /// <param name="identity">Unique identifier, usually beginning with "SU".</param> 
+        /// <param name="request">An optional `SchemeIdentifierGetRequest` representing the query parameters for this get request.</param>
+        /// <param name="customiseRequestMessage">An optional `RequestSettings` allowing you to configure the request</param>
+        /// <returns>A single scheme identifier resource</returns>
+        public Task<SchemeIdentifierResponse> GetAsync(string identity, SchemeIdentifierGetRequest request = null, RequestSettings customiseRequestMessage = null)
+        {
+            request = request ?? new SchemeIdentifierGetRequest();
+            if (identity == null) throw new ArgumentException(nameof(identity));
+
+            var urlParams = new List<KeyValuePair<string, object>>
+            {
+                new KeyValuePair<string, object>("identity", identity),
+            };
+
+            return _goCardlessClient.ExecuteAsync<SchemeIdentifierResponse>("GET", "/scheme_identifiers/:identity", urlParams, request, null, null, customiseRequestMessage);
+        }
+    }
+
+        
+    /// <summary>
+    /// Returns a [cursor-paginated](#api-usage-cursor-pagination) list of your
+    /// scheme identifiers.
+    /// </summary>
+    public class SchemeIdentifierListRequest
+    {
+
+        /// <summary>
+        /// Cursor pointing to the start of the desired set.
+        /// </summary>
+        [JsonProperty("after")]
+        public string After { get; set; }
+
+        /// <summary>
+        /// Cursor pointing to the end of the desired set.
+        /// </summary>
+        [JsonProperty("before")]
+        public string Before { get; set; }
+
+        /// <summary>
+        /// Number of records to return.
+        /// </summary>
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+    }
+
+        
+    /// <summary>
+    /// Retrieves the details of an existing scheme identifier.
+    /// </summary>
+    public class SchemeIdentifierGetRequest
+    {
+    }
+
+    /// <summary>
+    /// An API response for a request returning a single scheme identifier.
+    /// </summary>
+    public class SchemeIdentifierResponse : ApiResponse
+    {
+        /// <summary>
+        /// The scheme identifier from the response.
+        /// </summary>
+        [JsonProperty("scheme_identifiers")]
+        public SchemeIdentifier SchemeIdentifier { get; private set; }
+    }
+
+    /// <summary>
+    /// An API response for a request returning a list of scheme identifiers.
+    /// </summary>
+    public class SchemeIdentifierListResponse : ApiResponse
+    {
+        /// <summary>
+        /// The list of scheme identifiers from the response.
+        /// </summary>
+        [JsonProperty("scheme_identifiers")]
+        public IReadOnlyList<SchemeIdentifier> SchemeIdentifiers { get; private set; }
+        /// <summary>
+        /// Response metadata (e.g. pagination cursors)
+        /// </summary>
+        public Meta Meta { get; private set; }
+    }
+}

--- a/GoCardless/Services/VerificationDetailService.cs
+++ b/GoCardless/Services/VerificationDetailService.cs
@@ -35,7 +35,7 @@ namespace GoCardless.Services
         /// <summary>
         /// Verification details represent any information needed by GoCardless
         /// to verify a creditor.
-        /// Currently, only UK-based companies are supported. 
+        /// Currently, only UK-based companies are supported.
         /// In other words, to submit verification details for a creditor, their
         /// creditor_type must be company and their country_code must be GB.
         /// </summary>
@@ -57,7 +57,7 @@ namespace GoCardless.Services
     /// <summary>
     /// Verification details represent any information needed by GoCardless to
     /// verify a creditor.
-    /// Currently, only UK-based companies are supported. 
+    /// Currently, only UK-based companies are supported.
     /// In other words, to submit verification details for a creditor, their
     /// creditor_type must be company and their country_code must be GB.
     /// </summary>

--- a/GoCardless/Services/VerificationDetailService.cs
+++ b/GoCardless/Services/VerificationDetailService.cs
@@ -38,24 +38,18 @@ namespace GoCardless.Services
         /// Currently, only UK-based companies are supported. 
         /// In other words, to submit verification details for a creditor, their
         /// creditor_type must be company and their country_code must be GB.
-        /// </summary>  
-        /// <param name="identity">Unique identifier of the creditor these details are being stored
-        /// against,
-        /// beginning with "CR".</param> 
+        /// </summary>
         /// <param name="request">An optional `VerificationDetailCreateRequest` representing the body for this create request.</param>
         /// <param name="customiseRequestMessage">An optional `RequestSettings` allowing you to configure the request</param>
         /// <returns>A single verification detail resource</returns>
-        public Task<VerificationDetailResponse> CreateAsync(string identity, VerificationDetailCreateRequest request = null, RequestSettings customiseRequestMessage = null)
+        public Task<VerificationDetailResponse> CreateAsync(VerificationDetailCreateRequest request = null, RequestSettings customiseRequestMessage = null)
         {
             request = request ?? new VerificationDetailCreateRequest();
-            if (identity == null) throw new ArgumentException(nameof(identity));
 
             var urlParams = new List<KeyValuePair<string, object>>
-            {
-                new KeyValuePair<string, object>("identity", identity),
-            };
+            {};
 
-            return _goCardlessClient.ExecuteAsync<VerificationDetailResponse>("POST", "/verification_details/:identity", urlParams, request, null, "verification_details", customiseRequestMessage);
+            return _goCardlessClient.ExecuteAsync<VerificationDetailResponse>("POST", "/verification_details", urlParams, request, null, "verification_details", customiseRequestMessage);
         }
     }
 

--- a/GoCardless/Services/VerificationDetailService.cs
+++ b/GoCardless/Services/VerificationDetailService.cs
@@ -1,0 +1,200 @@
+
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using GoCardless.Internals;
+using GoCardless.Resources;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace GoCardless.Services
+{
+    /// <summary>
+    /// Service class for working with verification detail resources.
+    ///
+    /// Details of a creditor that are required for verification
+    /// </summary>
+
+    public class VerificationDetailService
+    {
+        private readonly GoCardlessClient _goCardlessClient;
+
+        /// <summary>
+        /// Constructor. Users of this library should not call this. An instance of this
+        /// class can be accessed through an initialised GoCardlessClient.
+        /// </summary>
+        public VerificationDetailService(GoCardlessClient goCardlessClient)
+        {
+            _goCardlessClient = goCardlessClient;
+        }
+
+        /// <summary>
+        /// Verification details represent any information needed by GoCardless
+        /// to verify a creditor.
+        /// Currently, only UK-based companies are supported. 
+        /// In other words, to submit verification details for a creditor, their
+        /// creditor_type must be company and their country_code must be GB.
+        /// </summary>  
+        /// <param name="identity">Unique identifier of the creditor these details are being stored
+        /// against,
+        /// beginning with "CR".</param> 
+        /// <param name="request">An optional `VerificationDetailCreateRequest` representing the body for this create request.</param>
+        /// <param name="customiseRequestMessage">An optional `RequestSettings` allowing you to configure the request</param>
+        /// <returns>A single verification detail resource</returns>
+        public Task<VerificationDetailResponse> CreateAsync(string identity, VerificationDetailCreateRequest request = null, RequestSettings customiseRequestMessage = null)
+        {
+            request = request ?? new VerificationDetailCreateRequest();
+            if (identity == null) throw new ArgumentException(nameof(identity));
+
+            var urlParams = new List<KeyValuePair<string, object>>
+            {
+                new KeyValuePair<string, object>("identity", identity),
+            };
+
+            return _goCardlessClient.ExecuteAsync<VerificationDetailResponse>("POST", "/verification_details/:identity", urlParams, request, null, "verification_details", customiseRequestMessage);
+        }
+    }
+
+        
+    /// <summary>
+    /// Verification details represent any information needed by GoCardless to
+    /// verify a creditor.
+    /// Currently, only UK-based companies are supported. 
+    /// In other words, to submit verification details for a creditor, their
+    /// creditor_type must be company and their country_code must be GB.
+    /// </summary>
+    public class VerificationDetailCreateRequest
+    {
+
+        /// <summary>
+        /// The first line of the company's address.
+        /// </summary>
+        [JsonProperty("address_line1")]
+        public string AddressLine1 { get; set; }
+
+        /// <summary>
+        /// The second line of the company's address.
+        /// </summary>
+        [JsonProperty("address_line2")]
+        public string AddressLine2 { get; set; }
+
+        /// <summary>
+        /// The third line of the company's address.
+        /// </summary>
+        [JsonProperty("address_line3")]
+        public string AddressLine3 { get; set; }
+
+        /// <summary>
+        /// The city of the company's address.
+        /// </summary>
+        [JsonProperty("city")]
+        public string City { get; set; }
+
+        /// <summary>
+        /// The company's registration number.
+        /// </summary>
+        [JsonProperty("company_number")]
+        public string CompanyNumber { get; set; }
+
+        /// <summary>
+        /// A summary describing what the company does.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The company's directors.
+        /// </summary>
+        [JsonProperty("directors")]
+        public VerificationDetailDirectors[] Directors { get; set; }
+        /// <summary>
+        /// A primary director of the company represented by the creditor.
+        /// </summary>
+        public class VerificationDetailDirectors
+        {
+                
+                /// <summary>
+                            /// The city of the person's address.
+                /// </summary>
+                [JsonProperty("city")]
+                public string City { get; set; }
+                
+                /// <summary>
+                            /// [ISO 3166-1 alpha-2
+            /// code.](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements)
+                /// </summary>
+                [JsonProperty("country_code")]
+                public string CountryCode { get; set; }
+                
+                /// <summary>
+                            /// The person's date of birth.
+                /// </summary>
+                [JsonProperty("date_of_birth")]
+                public string DateOfBirth { get; set; }
+                
+                /// <summary>
+                            /// The person's family name.
+                /// </summary>
+                [JsonProperty("family_name")]
+                public string FamilyName { get; set; }
+                
+                /// <summary>
+                            /// The person's given name.
+                /// </summary>
+                [JsonProperty("given_name")]
+                public string GivenName { get; set; }
+                
+                /// <summary>
+                            /// The person's postal code.
+                /// </summary>
+                [JsonProperty("postal_code")]
+                public string PostalCode { get; set; }
+                
+                /// <summary>
+                            /// The street of the person's address.
+                /// </summary>
+                [JsonProperty("street")]
+                public string Street { get; set; }
+        }
+
+        /// <summary>
+        /// Linked resources.
+        /// </summary>
+        [JsonProperty("links")]
+        public VerificationDetailLinks Links { get; set; }
+        /// <summary>
+        /// Linked resources for a VerificationDetail.
+        /// </summary>
+        public class VerificationDetailLinks
+        {
+                
+                /// <summary>
+                            /// ID of the associated [creditor](#core-endpoints-creditors).
+                /// </summary>
+                [JsonProperty("creditor")]
+                public string Creditor { get; set; }
+        }
+
+        /// <summary>
+        /// The company's postal code.
+        /// </summary>
+        [JsonProperty("postal_code")]
+        public string PostalCode { get; set; }
+    }
+
+    /// <summary>
+    /// An API response for a request returning a single verification detail.
+    /// </summary>
+    public class VerificationDetailResponse : ApiResponse
+    {
+        /// <summary>
+        /// The verification detail from the response.
+        /// </summary>
+        [JsonProperty("verification_details")]
+        public VerificationDetail VerificationDetail { get; private set; }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For full details of the GoCardless API, see the [API docs](https://developer.goc
 
 To install `GoCardless`, run the following command in the [Package Manager Console](https://docs.microsoft.com/en-us/nuget/tools/package-manager-console)
 
-`Install-Package GoCardless -Version 5.11.0`
+`Install-Package GoCardless -Version 5.12.0`
 
 
 ## Usage


### PR DESCRIPTION
This release contains

- Adding POST /verification_details endpoint, which allows integrators to submit creditor based kyc information via the API
 
- Exposes Scheme idenfitiers for Create/Get/List via the API, and allows scheme Identifiers to be applied to creditors via the /creditors/:identity/actions/apply_scheme_identifier route added
 
- verified_at attribute added to mandate resource