### PR TITLE
Automatically release new versions

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -1,6 +1,10 @@
 name: build_and_publish
 on: push
 
+permissions:
+  id-token: write
+  contents: write
+
 env:
   NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
 
@@ -25,11 +29,35 @@ jobs:
       with:
         path: "GoCardless/bin/Release/*.nupkg"
 
-  publish:
+  check_version:
     if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    outputs:
+      should_publish: ${{ steps.check.outputs.should_publish }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Check if version tag exists
+      id: check
+      run: |
+        VERSION=$(grep -oP '(?<=<PackageVersion>)[^<]+' GoCardless/GoCardless.csproj)
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        if git rev-parse "v${VERSION}" >/dev/null 2>&1; then
+          echo "Tag v${VERSION} already exists, skipping publish"
+          echo "should_publish=false" >> $GITHUB_OUTPUT
+        else
+          echo "Tag v${VERSION} does not exist, will publish"
+          echo "should_publish=true" >> $GITHUB_OUTPUT
+        fi
+
+  publish:
+    if: github.ref == 'refs/heads/master' && needs.check_version.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     needs:
     - build_and_test
+    - check_version
     env:
       OUT_DIR: "artifact"
     steps:
@@ -40,3 +68,23 @@ jobs:
         dotnet-version: '8.0.x'
     - name: Publish the library
       run: dotnet nuget push artifact/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }} -n --skip-duplicate
+
+  create_release:
+    if: github.ref == 'refs/heads/master' && needs.check_version.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    needs:
+    - publish
+    - check_version
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Create tag and release
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git tag v${{ needs.check_version.outputs.version }}
+        git push origin v${{ needs.check_version.outputs.version }}
+        gh release create v${{ needs.check_version.outputs.version }} --generate-notes
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When the version is bumped and merged to master, this will check to see if the release already exists and if it doesn't, it will publish to nuget and create the github release.

The version is controlled in the client-library-templates repo.

This is copied from nodejs: https://github.com/gocardless/gocardless-nodejs/blob/master/.github/workflows/test-and-deploy.yml#L33-L95