### PR TITLE
Add pull_request trigger to CI workflow

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -33,6 +33,19 @@ jobs:
       with:
         path: "GoCardless/bin/Release/*.nupkg"
 
+  all-tests-passed:
+    name: All tests passed
+    runs-on: ubuntu-latest
+    needs: [build_and_test]
+    if: always()
+    steps:
+    - name: Check build_and_test job status
+      run: |
+        if [ "${{ needs.build_and_test.result }}" != "success" ]; then
+          echo "build_and_test job did not succeed"
+          exit 1
+        fi
+
   check_version:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -1,5 +1,9 @@
 name: build_and_publish
-on: push
+on:
+  push:
+    branches: [master]
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 permissions:
   id-token: write


### PR DESCRIPTION
## Summary
- Adds a `pull_request` trigger alongside the existing `push` trigger so `build_and_test` runs against fork PRs, not just pushes to the repo.
- Restricts the `push` trigger to `master` only (post-merge publish flow is unaffected - it already gates on `github.ref == 'refs/heads/master'`).

## Why
Part of IX-2323: setting up required status checks across GoCardless's public client library repos so we can safely enable auto-merge. A push-only trigger never runs against a fork PR's head commit, so requiring `build_and_test` in branch protection would otherwise block every external contribution.

## Test plan
- [x] Confirm `build_and_test` appears as a check on this PR