### PR TITLE
Explicitly set release title and fix broken variable references

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -52,6 +52,7 @@ jobs:
     outputs:
       should_publish: ${{ steps.check.outputs.should_publish }}
       version: ${{ steps.check.outputs.version }}
+      notes: ${{ steps.notes.outputs.notes }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -119,13 +120,14 @@ jobs:
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
-        git tag v${{ needs.check_version.outputs.version }}
-        git push origin v${{ needs.check_version.outputs.version }}
-        NOTES="${{ steps.notes.outputs.notes }}"
+        TAG="v${{ needs.check_version.outputs.version }}"
+        git tag "$TAG"
+        git push origin "$TAG"
+        NOTES="${{ needs.check_version.outputs.notes }}"
         if [ -n "$(echo "$NOTES" | tr -d '[:space:]')" ]; then
-          gh release create v${{ steps.version.outputs.version }} --notes "$NOTES"
+          gh release create "$TAG" --title "$TAG" --notes "$NOTES"
         else
-          gh release create v${{ steps.version.outputs.version }} --generate-notes
+          gh release create "$TAG" --title "$TAG" --generate-notes
         fi
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
* `gh release create` was leaving the release title blank when notes come from the changelog (`--notes`), so GitHub fell back to showing the merge commit message as the title instead of e.g. "v9.9.0".
* Separately, the `create_release` step referenced `steps.version` and `steps.notes`, which don't exist in that job's scope (the version-check and notes-extraction steps actually run in the `check_version` job) - these expressions always evaluated to empty, so releases were being tagged literally `v` with no notes. The notes step's output is now wired through `check_version`'s job outputs, and `needs.check_version.outputs.*` is used consistently.

This mirrors the release-title fix applied in gocardless-nodejs (gocardless/gocardless-nodejs#256), plus a repo-specific bug fix here.

## Test plan
- [ ] Confirm the next automated release gets tagged correctly (e.g. `v9.9.0`, not `v`), with the correct title and changelog notes