### PR TITLE
Remove the publishing key from the env (as it is not needed)

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -9,9 +9,6 @@ permissions:
   id-token: write
   contents: write
 
-env:
-  NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-
 jobs:
   build_and_test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Remove the key needed for publishing the nugget from env variables, because it is accessed in the pipeline as a secret directly. 

This is done in an effort to minimize the risk of a supply chain attack. 